### PR TITLE
CLI make tool to add a new company to readme table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,9 @@ help: ## Mostra esta ajuda
 sort: ## Ordena as empresas na tabela do README.md
 	@./scripts/sort.sh
 
+add: ## Adiciona uma nova empresa à tabela do README.md > make add "Nome da empresa - link.site - link.stackshare or keep empty - link.vagas - tipo de contratação"
+	@./scripts/add/add.sh $(filter-out $@,$(MAKECMDGOALS))
+%:
+	@:
+
 .DEFAULT_GOAL := help

--- a/scripts/add/add.sh
+++ b/scripts/add/add.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$(dirname "$SCRIPT_DIR")")"
+README_PATH="$PROJECT_ROOT/README.md"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+echo -e "${BLUE}🏗️  Adicionando nova empresa ao README.md...${NC}"
+
+if [ ! -f "$README_PATH" ]; then
+    echo -e "${RED}❌ README.md não encontrado!${NC}"
+    exit 1
+fi
+
+if ! command -v go &> /dev/null; then
+    echo -e "${RED}❌ Go não encontrado!${NC}"
+    echo -e "${YELLOW}💡 Instale Go para usar este script:${NC}"
+    echo -e "${YELLOW}   https://go.dev/dl/${NC}"
+    exit 1
+fi
+
+INPUT="$*"
+
+if [ -z "$INPUT" ]; then
+    echo -e "${RED}❌ Uso incorreto!${NC}"
+    echo -e "${YELLOW}👉 make add \"Nome da empresa - link.site - link.stackshare or keep empty - link.vagas - tipo de contratação\"${NC}"
+    exit 1
+fi
+
+echo -e "${YELLOW}🐹 Executando script para adicionar empresa...${NC}"
+cd "$PROJECT_ROOT"
+
+go run "$SCRIPT_DIR/add_company.go" "$INPUT"
+
+echo -e "${GREEN}✅ Empresa adicionada com sucesso ao README.md!${NC}"

--- a/scripts/add/add_company.go
+++ b/scripts/add/add_company.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/viniciusgabrielfo/empresas-golang/scripts/table"
+)
+
+const (
+	minTableColumns = 4
+	tableSeparator  = "---"
+	readmeFileName  = "README.md"
+
+	errFileNotFound  = "README.md not found"
+	errTableNotFound = "could not find table in README.md"
+	errFileOpen      = "failed to open file"
+	errFileRead      = "failed to read file"
+	errFileCreate    = "failed to create file"
+	errFileWrite     = "failed to write file"
+	errArgInput      = "expected argument enclosed in quotes (\"\"), with 4 or 5 fields separated by hyphens ( - ). Example:\n make add \"Nome da empresa - link.site - link.stackshare or keep empty - link.vagas - tipo de contratação\""
+)
+
+type NewCompany struct {
+	Name         string
+	OficialLink  string
+	Stackshare   string
+	JobsLink     string
+	ContractType string
+}
+
+func createCompany(args []string) (*NewCompany, error) {
+
+	if len(args) <= 1 {
+		return nil, fmt.Errorf("%s", errArgInput)
+	}
+
+	input := args[1]
+	parts := strings.Split(input, " -")
+
+	if len(parts) < 4 || len(parts) > 5 {
+		return nil, fmt.Errorf("%s", errArgInput)
+	}
+
+	newCompany := &NewCompany{}
+
+	if strings.Contains(parts[0], "http") {
+		return nil, fmt.Errorf("first argument field must be the company name, not a link\n%s", errArgInput)
+	}
+	newCompany.Name = strings.TrimSpace(parts[0])
+
+	if !strings.Contains(parts[1], "http") {
+		return nil, fmt.Errorf("second argument field must be a link to the company's oficial site\n%s", errArgInput)
+	}
+	newCompany.OficialLink = strings.TrimSpace(parts[1])
+
+	if !strings.Contains(parts[2], "http") {
+		return nil, fmt.Errorf("third argument field must be a link to the company's stackshare profile, or must be omitted\n%s", errArgInput)
+	}
+	if !strings.Contains(parts[2], "stackshare.io") {
+		newCompany.Stackshare = ""
+
+		newCompany.JobsLink = strings.TrimSpace(parts[2])
+	} else {
+		newCompany.Stackshare = strings.TrimSpace(parts[2])
+		if !strings.Contains(parts[3], "http") {
+			return nil, fmt.Errorf("fourth argument field must be a link to the company's jobs page\n%s", errArgInput)
+		}
+		newCompany.JobsLink = strings.TrimSpace(parts[3])
+	}
+
+	contractField := strings.TrimSpace(parts[len(parts)-1])
+	if !(contractField == "NACIONAL" || contractField == "INTERNATIONAL" || contractField == "NACIONAL/INTERNATIONAL") {
+		return nil, fmt.Errorf("last argument field must be NACIONAL, INTERNATIONAL, or NATIONAL/INTERNATIONAL\n%s", errArgInput)
+	}
+	newCompany.ContractType = contractField
+
+	return newCompany, nil
+}
+
+func addCompanyToReadme(readmePath string, newCompany *NewCompany) error {
+	content, err := os.ReadFile(readmePath)
+	if err != nil {
+		return fmt.Errorf("%s: %w", errFileOpen, err)
+	}
+
+	lines := strings.Split(string(content), "\n")
+
+	tableStart, tableEnd, err := table.FindTableBoundaries(lines)
+	if err != nil {
+		return err
+	}
+
+	companies, err := table.ExtractCompanies(lines, tableStart, tableEnd)
+	if err != nil {
+		return err
+	}
+
+	if err := duplicityCheck(companies, newCompany); err != nil {
+		return err
+	}
+
+	companies = addNewCompany(companies, newCompany)
+
+	newLines := table.RebuildFileContent(lines, companies, tableStart, tableEnd)
+
+	if err := table.WriteFile(readmePath, newLines); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func addNewCompany(companies []table.Company, newCompany *NewCompany) []table.Company {
+	company := table.Company{}
+
+	company.NameLink = fmt.Sprintf("[%s](%s)", newCompany.Name, newCompany.OficialLink)
+	if newCompany.Stackshare != "" {
+		company.Stackshare = fmt.Sprintf("[Clique aqui](%s)", newCompany.Stackshare)
+	}
+	company.JobsLink = fmt.Sprintf("[Clique aqui](%s)", newCompany.JobsLink)
+	company.ContractType = newCompany.ContractType
+
+	//TODO: format code table too, not just the markdown table
+	company.OriginalLine = fmt.Sprintf("| %s | %s | %s | %s |", company.NameLink, company.Stackshare, company.JobsLink, company.ContractType)
+
+	companies = append(companies, company)
+	return companies
+}
+
+func duplicityCheck(companies []table.Company, newCompany *NewCompany) error {
+	newName := table.NormalizeName(newCompany.Name)
+	newName = strings.Join(strings.Fields(newName), "")
+
+	for _, company := range companies {
+		existingName := table.NormalizeName(table.ExtractCompanyName(company.NameLink))
+		existingName = strings.Join(strings.Fields(existingName), "")
+
+		if strings.Contains(existingName, newName) || strings.Contains(newName, existingName) {
+			return fmt.Errorf("the company seems to already be in the table with this name: %s", table.ExtractCompanyName(company.NameLink))
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	newCompany, err := createCompany(os.Args)
+	if err != nil {
+		log.Fatalf("❌ Parsing arguments: %v", err)
+	}
+
+	readmePath := table.ReadmeFileName
+
+	if _, err := os.Stat(readmePath); os.IsNotExist(err) {
+		log.Fatalf("❌ %s", errFileNotFound)
+	}
+
+	fmt.Println("🏗️ Adding company to README.md...")
+
+	if err := addCompanyToReadme(readmePath, newCompany); err != nil {
+		log.Fatalf("❌ Adding error: %v", err)
+	}
+}

--- a/scripts/table/table.go
+++ b/scripts/table/table.go
@@ -1,0 +1,166 @@
+package table
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+const (
+	minTableColumns = 4
+	tableSeparator  = "---"
+	ReadmeFileName  = "README.md"
+
+	errFileNotFound  = "README.md not found"
+	errTableNotFound = "could not find table in README.md"
+	errFileOpen      = "failed to open file"
+	errFileRead      = "failed to read file"
+	errFileCreate    = "failed to create file"
+	errFileWrite     = "failed to write file"
+)
+
+// Company represents a company entry in the README table
+type Company struct {
+	NameLink     string `json:"name_link"`
+	Stackshare   string `json:"stackshare"`
+	JobsLink     string `json:"jobs_link"`
+	ContractType string `json:"contract_type"`
+	OriginalLine string `json:"original_line"`
+}
+
+var (
+	companyNameRegex = regexp.MustCompile(`\[([^\]]+)\]`)
+	articles         = []string{"A ", "O ", "De ", "Da ", "Do ", "The "}
+)
+
+// normalizeName removes common articles from company names for consistent sorting
+func NormalizeName(name string) string {
+	normalized := strings.TrimSpace(name)
+
+	for _, article := range articles {
+		if strings.HasPrefix(normalized, article) {
+			normalized = normalized[len(article):]
+			break
+		}
+	}
+
+	return strings.ToLower(normalized)
+}
+
+// extractCompanyName extracts the company name from markdown link format [Name](url)
+func ExtractCompanyName(companyLink string) string {
+	matches := companyNameRegex.FindStringSubmatch(companyLink)
+	if len(matches) > 1 {
+		return strings.TrimSpace(matches[1])
+	}
+	return strings.TrimSpace(companyLink)
+}
+
+func FindTableBoundaries(lines []string) (int, int, error) {
+	tableStart := -1
+	tableEnd := -1
+
+	for i, line := range lines {
+		if strings.Contains(line, "| Nome") && strings.Contains(line, "| Stackshare") {
+			tableStart = i
+		} else if tableStart != -1 && strings.TrimSpace(line) == "" {
+			tableEnd = i
+			break
+		}
+	}
+
+	if tableStart == -1 {
+		return -1, -1, errors.New(errTableNotFound)
+	}
+
+	if tableEnd == -1 {
+		tableEnd = len(lines)
+	}
+
+	return tableStart, tableEnd, nil
+}
+
+func ExtractCompanies(lines []string, tableStart, tableEnd int) ([]Company, error) {
+	companies := make([]Company, 0, tableEnd-tableStart-2)
+
+	for i := tableStart + 2; i < tableEnd; i++ {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+
+		company := parseTableLine(line)
+		if company != nil {
+			companies = append(companies, *company)
+		}
+	}
+
+	return companies, nil
+}
+
+// parseTableLine parses a markdown table line and returns a Company struct
+func parseTableLine(line string) *Company {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, "|") || strings.Contains(line, tableSeparator) {
+		return nil
+	}
+
+	// Remove leading and trailing pipes
+	content := line[1 : len(line)-1]
+	parts := strings.Split(content, "|")
+
+	if len(parts) < minTableColumns {
+		return nil
+	}
+
+	// Trim spaces from all parts
+	for i, part := range parts {
+		parts[i] = strings.TrimSpace(part)
+	}
+
+	return &Company{
+		NameLink:     parts[0],
+		Stackshare:   parts[1],
+		JobsLink:     parts[2],
+		ContractType: parts[3],
+		OriginalLine: line,
+	}
+}
+
+func RebuildFileContent(lines []string, companies []Company, tableStart, tableEnd int) []string {
+	newLines := make([]string, 0, len(lines))
+
+	newLines = append(newLines, lines[:tableStart]...)
+	newLines = append(newLines, lines[tableStart])
+	newLines = append(newLines, lines[tableStart+1])
+
+	for _, company := range companies {
+		newLines = append(newLines, company.OriginalLine)
+	}
+
+	newLines = append(newLines, lines[tableEnd:]...)
+
+	return newLines
+}
+
+func WriteFile(filePath string, lines []string) error {
+	file, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("%s: %w", errFileCreate, err)
+	}
+	defer file.Close()
+
+	writer := bufio.NewWriter(file)
+	defer writer.Flush()
+
+	for _, line := range lines {
+		if _, err := writer.WriteString(line + "\n"); err != nil {
+			return fmt.Errorf("%s: %w", errFileWrite, err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Olá! Ainda um draft PR pra ver se podemos seguir nesse caminho...

Alguma considerações para a revisão:

1) Procurei não mexer nos arquivos `sort.sh` e `sort_companies.go` por enquanto, usando-os como modelo e COPIANDO boa parte das suas funções para o novo arquivo `table.go`, deixando-as agora como funções exportadas, para que `add_company.go` pudesse usá-las. A ideia é que - se essa primeira versão for aprovada - depois possamos retirar essas funções duplicadas do arquivo `sort_companies.go` e fazê-lo importá-las também de `table.go`, mudando para essa estrutura:
scripts
├── add
│   ├── add.sh
│   └── add_company.go
├── sort
│   ├── sort.sh
│   └── sort_companies.go
└── table
    └── table.go
    
2) Me dei conta que, mesmo que o código do `readme.md` aberto no editor pareça bagunçado por causa dos espaçamentos, a tabela exibida na tela do GitHub fica correta, pois é apenas um markdown. Por causa disso, por enquanto minha make tool não está se importando em deixar a visualização do editor correta, com os pipes e espaçamentos corretos, mas somente se importando com a visualização final. Posso trabalhar nisso depois.

3) Não adicionei testes automatizados, mas posso fazê-lo depois, se achares que é importante.

4) Não deixei o ordenamento automático. Penso que o fluxo de quem estiver adicionando pode ser:
- make add "argumentos"
- confere no final da tabela
- make sort
- confere novamente a ordenação

5) Já dexei "default" a conferência de entradas duplicadas. Vale analisar.